### PR TITLE
Bugfix/did end displaying cell

### DIFF
--- a/EssentialApp/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		B3EA7D462C1BD216009916B1 /* FeedAcceptanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EA7D452C1BD216009916B1 /* FeedAcceptanceTests.swift */; };
 		B3EA7D482C1BDE58009916B1 /* HTTPClientStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EA7D472C1BDE58009916B1 /* HTTPClientStub.swift */; };
 		B3EA7D4A2C1BDE9A009916B1 /* InMemoryFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EA7D492C1BDE9A009916B1 /* InMemoryFeedStore.swift */; };
+		B3EA7D572C1CFE6C009916B1 /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EA7D562C1CFE6C009916B1 /* UIView+TestHelpers.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -134,6 +135,7 @@
 		B3EA7D452C1BD216009916B1 /* FeedAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAcceptanceTests.swift; sourceTree = "<group>"; };
 		B3EA7D472C1BDE58009916B1 /* HTTPClientStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientStub.swift; sourceTree = "<group>"; };
 		B3EA7D492C1BDE9A009916B1 /* InMemoryFeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryFeedStore.swift; sourceTree = "<group>"; };
+		B3EA7D562C1CFE6C009916B1 /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -183,6 +185,7 @@
 				B355046E2C1A483800C2443D /* XCTestCase+FeedImageDataLoader.swift */,
 				B3EA7D472C1BDE58009916B1 /* HTTPClientStub.swift */,
 				B3EA7D492C1BDE9A009916B1 /* InMemoryFeedStore.swift */,
+				B3EA7D562C1CFE6C009916B1 /* UIView+TestHelpers.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -434,6 +437,7 @@
 				B3EA7D3C2C1BCFD1009916B1 /* UIRefreshControl+TestHelpers.swift in Sources */,
 				B3EA7D482C1BDE58009916B1 /* HTTPClientStub.swift in Sources */,
 				B32144672B741140009F2E59 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
+				B3EA7D572C1CFE6C009916B1 /* UIView+TestHelpers.swift in Sources */,
 				B3EA7D412C1BCFD1009916B1 /* FeedViewController+TestHelpers.swift in Sources */,
 				B3EA7D3A2C1BCFD1009916B1 /* UIImage+TestHelpers.swift in Sources */,
 				B3EA7D462C1BD216009916B1 /* FeedAcceptanceTests.swift in Sources */,

--- a/EssentialApp/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -69,6 +69,20 @@ final class FeedUIIntegrationTests: XCTestCase {
         assertThat(sut, isRendering: [image0, image1, image2, image3])
     }
     
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+        
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
+    }
+    
     func test_loadFeedCompletion_doesNotAlterCurrentrenderingStateOnError() {
         let image0 = makeImage()
         let (sut, loader) = makeSUT()

--- a/EssentialApp/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
+++ b/EssentialApp/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
@@ -12,6 +12,9 @@ import EssentialFeediOS
 extension FeedUIIntegrationTests {
     
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.main.run(until: Date())
+        
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }

--- a/EssentialApp/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
+++ b/EssentialApp/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
@@ -12,8 +12,7 @@ import EssentialFeediOS
 extension FeedUIIntegrationTests {
     
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
-        sut.tableView.layoutIfNeeded()
-        RunLoop.main.run(until: Date())
+        sut.view.enforceLayoutCycle()
         
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)

--- a/EssentialApp/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
+++ b/EssentialApp/EssentialApp/EssentialAppTests/Helpers/UIView+TestHelpers.swift
@@ -1,0 +1,15 @@
+//
+//  UIView+TestHelpers.swift
+//  EssentialAppTests
+//
+//  Created by Jin Zhang on 6/14/24.
+//
+
+import UIKit
+
+extension UIView {
+    func enforceLayoutCycle() {
+        layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+    }
+}

--- a/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -17,6 +17,8 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     
     @IBOutlet private(set) public var errorView: ErrorView?
     
+    private var loadingControllers = [IndexPath: FeedImageCellController]()
+    
     private var tableModel = [FeedImageCellController]() {
         didSet { tableView.reloadData() }
     }
@@ -44,6 +46,7 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
     
@@ -82,10 +85,13 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        return tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
     
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }


### PR DESCRIPTION
When updating the table model and reloading the table, UIKit calls didEndDisplayingCell for each removed cell that was previously visible. Since we're canceling requests in this method, we could be sending messages to the new models or potentially crashing in case the new table model has fewer items than the previous one!

This is not a big problem at the moment since items cannot be removed from the feed. But we cannot assume the backend will keep this behavior going further.